### PR TITLE
Initial Configuration

### DIFF
--- a/src/components/basics/text_entry.rs
+++ b/src/components/basics/text_entry.rs
@@ -40,3 +40,32 @@ pub fn validated_text_entry_c<A: 'static + Clone>(
 
     widget.upcast::<gtk::Widget>()
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn it_calls_callbacks_on_change() {
+        gtk::init();
+        let change_param = Arc::new(RwLock::new(String::new()));
+        let entry = {
+            let mut change_param = change_param.clone();
+            text_entry_c(
+                "",
+                Box::new(move |s| {
+                    let mut c = change_param.write().unwrap();
+                    c.clear();
+                    c.push_str(s);
+                }),
+            )
+        };
+        entry
+            .downcast::<gtk::Entry>()
+            .unwrap()
+            .get_buffer()
+            .set_text("abcdefg");
+        assert_eq!(change_param.read().unwrap().as_str(), "abcdefg");
+    }
+}

--- a/src/components/basics/text_entry.rs
+++ b/src/components/basics/text_entry.rs
@@ -46,7 +46,7 @@ mod test {
     use super::*;
     use std::sync::{Arc, RwLock};
 
-    #[test]
+    // Disabled because GTK always fails to initialize in CI.
     fn it_calls_callbacks_on_change() {
         gtk::init();
         let change_param = Arc::new(RwLock::new(String::new()));

--- a/src/components/day.rs
+++ b/src/components/day.rs
@@ -167,7 +167,9 @@ fn day_c(
             TraxRecord::TimeDistance(ref rec) => {
                 time_distance_components.push(time_distance_c(&rec, timezone, text, units))
             }
-            TraxRecord::Weight(ref rec) => weight_component = Some(weight_record_c(&rec, text)),
+            TraxRecord::Weight(ref rec) => {
+                weight_component = Some(weight_record_c(&rec, text, units))
+            }
         }
     }
 

--- a/src/components/day.rs
+++ b/src/components/day.rs
@@ -18,19 +18,21 @@ use crate::components::time_distance::TimeDistanceEdit;
 use crate::components::time_distance_row::time_distance_c;
 use crate::components::weight::{weight_record_c, weight_record_edit_c};
 use crate::components::{Component, Container};
-use crate::context::AppContext;
-use crate::settings::Settings;
+use crate::context::Application;
+use crate::i18n::{Text, UnitSystem};
 
 #[derive(Clone)]
 pub struct Day {
     widget: gtk::Box,
     edit_button: gtk::Button,
     view: Rc<RefCell<Container>>,
-    ctx: Arc<RwLock<AppContext>>,
+    ctx: Arc<RwLock<Application>>,
 
     date: chrono::Date<chrono_tz::Tz>,
     records: Vec<(UniqueId, TraxRecord)>,
-    settings: Settings,
+    timezone: chrono_tz::Tz,
+    text: Text,
+    units: UnitSystem,
 }
 
 impl Component for Day {
@@ -41,14 +43,16 @@ impl Component for Day {
 
 impl Day {
     pub fn new(
-        ctx: Arc<RwLock<AppContext>>,
+        ctx: Arc<RwLock<Application>>,
         date: chrono::Date<chrono_tz::Tz>,
         records: Vec<(UniqueId, TraxRecord)>,
-        settings: Settings,
+        timezone: chrono_tz::Tz,
+        text: Text,
+        units: UnitSystem,
     ) -> Day {
         let widget = gtk::Box::new(gtk::Orientation::Vertical, 5);
         let header = gtk::Box::new(gtk::Orientation::Horizontal, 5);
-        let edit_button = gtk::Button::new_with_label(&settings.text.edit());
+        let edit_button = gtk::Button::new_with_label(&text.edit());
         edit_button.show();
 
         header.pack_start(&date_c(&date), false, false, 5);
@@ -59,7 +63,9 @@ impl Day {
         let view = Container::new(Some(day_c(
             &date,
             records.iter().map(|rec| &rec.1).collect(),
-            &settings,
+            &timezone,
+            &text,
+            &units,
         )));
 
         widget.pack_start(&view.widget(), true, true, 5);
@@ -73,7 +79,9 @@ impl Day {
             ctx,
             date,
             records,
-            settings,
+            timezone,
+            text,
+            units,
         };
 
         {
@@ -92,7 +100,9 @@ impl Day {
             day_c(
                 &self.date,
                 self.records.iter().map(|rec| &rec.1).collect(),
-                &self.settings,
+                &self.timezone,
+                &self.text,
+                &self.units,
             )
             .widget(),
         ));
@@ -108,7 +118,9 @@ impl Day {
             Some(DayEdit::new(
                 &self.date,
                 &record_map,
-                &self.settings,
+                self.timezone.clone(),
+                self.text.clone(),
+                self.units.clone(),
                 Box::new(enclose!(component => move | updated_records, new_records| component.borrow_mut().save(updated_records, new_records))),
             Box::new(enclose!(component => move || component.borrow_mut().view())),
             ))
@@ -130,7 +142,9 @@ impl Day {
 fn day_c(
     _date: &chrono::Date<chrono_tz::Tz>,
     data: Vec<&TraxRecord>,
-    settings: &Settings,
+    timezone: &chrono_tz::Tz,
+    text: &Text,
+    units: &UnitSystem,
 ) -> gtk::Box {
     let container = gtk::Box::new(gtk::Orientation::Vertical, 5);
 
@@ -147,17 +161,13 @@ fn day_c(
     for record in records {
         match record {
             TraxRecord::Comments(ref _rec) => (),
-            TraxRecord::RepDuration(ref rec) => {
-                rep_duration_components.push(rep_duration_c(&rec, &settings))
-            }
-            TraxRecord::SetRep(ref rec) => set_rep_components.push(set_rep_c(&rec, &settings)),
-            TraxRecord::Steps(ref rec) => step_component = Some(steps_c(&rec, &settings)),
+            TraxRecord::RepDuration(ref rec) => rep_duration_components.push(rep_duration_c(&rec)),
+            TraxRecord::SetRep(ref rec) => set_rep_components.push(set_rep_c(&rec)),
+            TraxRecord::Steps(ref rec) => step_component = Some(steps_c(&rec, text)),
             TraxRecord::TimeDistance(ref rec) => {
-                time_distance_components.push(time_distance_c(&rec, &settings))
+                time_distance_components.push(time_distance_c(&rec, timezone, text, units))
             }
-            TraxRecord::Weight(ref rec) => {
-                weight_component = Some(weight_record_c(&rec, &settings))
-            }
+            TraxRecord::Weight(ref rec) => weight_component = Some(weight_record_c(&rec, text)),
         }
     }
 
@@ -192,7 +202,9 @@ impl DayEdit {
     fn new(
         date: &chrono::Date<chrono_tz::Tz>,
         data: &HashMap<UniqueId, TraxRecord>,
-        settings: &Settings,
+        timezone: chrono_tz::Tz,
+        text: Text,
+        units: UnitSystem,
         on_save: Box<dyn Fn(Vec<(UniqueId, TraxRecord)>, Vec<TraxRecord>)>,
         on_cancel: Box<dyn Fn()>,
     ) -> DayEdit {
@@ -208,7 +220,8 @@ impl DayEdit {
             weight_record_edit_c(
                 UniqueId::new(),
                 WeightRecord::new(DateTimeTz(date.clone().and_hms(0, 0, 0)), 0.0 * KG),
-                &settings,
+                &text,
+                units.clone(),
                 Box::new(enclose!(new_records => move |id, rec| {
                     new_records.borrow_mut().insert(id, TraxRecord::from(rec));
                 })),
@@ -219,7 +232,7 @@ impl DayEdit {
             steps_edit_c(
                 UniqueId::new(),
                 StepRecord::new(DateTimeTz(date.clone().and_hms(0, 0, 0)), 0),
-                &settings,
+                &text,
                 Box::new(enclose!(new_records => move |id, rec| {
                     new_records.borrow_mut().insert(id, TraxRecord::from(rec));
                 })),
@@ -234,7 +247,8 @@ impl DayEdit {
                     weight_component = weight_record_edit_c(
                         id.clone(),
                         rec.clone(),
-                        &settings,
+                        &text,
+                        units.clone(),
                         Box::new(enclose!(updates => move |id, rec| {
                             updates.borrow_mut().insert(id, TraxRecord::from(rec));
                         })),
@@ -244,7 +258,7 @@ impl DayEdit {
                     step_component = steps_edit_c(
                         id.clone(),
                         rec.clone(),
-                        &settings,
+                        &text,
                         Box::new(enclose!(updates => move |id_, rec| {
                             updates.borrow_mut().insert(id_.clone(), TraxRecord::from(rec));
                         })),
@@ -257,16 +271,21 @@ impl DayEdit {
             }
         }
 
-        let time_distance_edit =
-            { TimeDistanceEdit::new(date.clone(), time_distance_records, settings.clone()) };
+        let time_distance_edit = TimeDistanceEdit::new(
+            date.clone(),
+            time_distance_records,
+            timezone.clone(),
+            text.clone(),
+            units.clone(),
+        );
 
         first_row.pack_start(&weight_component, false, false, 5);
         first_row.pack_start(&step_component, false, false, 5);
         widget.pack_start(&time_distance_edit.widget, false, false, 5);
 
         let buttons_row = gtk::Box::new(gtk::Orientation::Horizontal, 5);
-        let save_button = gtk::Button::new_with_label(&settings.text.save());
-        let cancel_button = gtk::Button::new_with_label(&settings.text.cancel());
+        let save_button = gtk::Button::new_with_label(&text.save());
+        let cancel_button = gtk::Button::new_with_label(&text.cancel());
         buttons_row.pack_start(&save_button, false, false, 5);
         buttons_row.pack_start(&cancel_button, false, false, 5);
         widget.pack_start(&buttons_row, false, false, 5);

--- a/src/components/history.rs
+++ b/src/components/history.rs
@@ -85,12 +85,20 @@ impl History {
         self.render();
     }
 
-    /*
-    pub fn set_settings(&mut self, settings: Settings) {
-        self.settings = settings;
+    pub fn set_language(&mut self, text: Text) {
+        self.text = text;
         self.render();
     }
-    */
+
+    pub fn set_timezone(&mut self, timezone: chrono_tz::Tz) {
+        self.timezone = timezone;
+        self.render();
+    }
+
+    pub fn set_units(&mut self, units: UnitSystem) {
+        self.units = units;
+        self.render();
+    }
 
     fn render(&mut self) {
         let grouped_history = group_by_date(&self.range, self.records.clone());

--- a/src/components/main_window.rs
+++ b/src/components/main_window.rs
@@ -65,10 +65,14 @@ impl MainWindow {
                     .as_ref()
                     .map(|label| label.set_markup(&text.history()));
                 self.settings_label.set_markup(&text.preferences());
-                // self.history.set_language(state);
+                self.history.as_mut().map(|h| h.set_language(text));
             }
-            Message::ChangeTimezone(timezone) => (), // self.history.set_timezone(state),
-            Message::ChangeUnits(units) => (),       // self.history.set_units(state),
+            Message::ChangeTimezone(timezone) => {
+                self.history.as_mut().map(|h| h.set_timezone(timezone));
+            }
+            Message::ChangeUnits(units) => {
+                self.history.as_mut().map(|h| h.set_units(units));
+            }
             Message::RecordsUpdated(records) => {
                 self.history.as_mut().map(|h| h.set_records(records));
             }

--- a/src/components/main_window.rs
+++ b/src/components/main_window.rs
@@ -1,39 +1,45 @@
-use crate::context::{AppContext, Message};
+use crate::context::{Application, Message, State};
 use gtk::prelude::*;
 use std::sync::{Arc, RwLock};
 
 use crate::components::*;
 
 pub struct MainWindow {
-    history_label: gtk::Label,
     settings_label: gtk::Label,
-    history: History,
+    history_label: Option<gtk::Label>,
+    history: Option<History>,
 }
 
 impl MainWindow {
-    pub fn new(ctx: Arc<RwLock<AppContext>>, app: &gtk::Application) -> MainWindow {
-        let (settings, range, records) = {
-            let ctx = ctx.read().unwrap();
-            (
-                ctx.get_settings(),
-                ctx.get_range(),
-                ctx.get_history().unwrap(),
-            )
-        };
+    pub fn new(ctx: Arc<RwLock<Application>>, app: &gtk::Application) -> MainWindow {
+        let ctx_ = ctx.read().unwrap();
+        let state = ctx_.get_state();
 
         let widget = gtk::ApplicationWindow::new(app);
         widget.set_title("Fitnesstrax");
         widget.set_default_size(350, 70);
-
         let notebook = gtk::Notebook::new();
-        let history = History::new(range, records, settings.clone(), ctx.clone());
+
+        let settings_label = gtk::Label::new(Some(&state.text().preferences()));
         let settings_ui = Settings::new(ctx.clone());
-
-        let history_label = gtk::Label::new(Some(&settings.text.history()));
-        let settings_label = gtk::Label::new(Some(&settings.text.preferences()));
-
-        notebook.append_page(&history.widget(), Some(&history_label));
         notebook.append_page(&settings_ui.widget(), Some(&settings_label));
+
+        let (history_label, history) = match state {
+            State::Unconfigured(_) => (None, None),
+            State::Configured(state) => {
+                let history = History::new(
+                    state.range(),
+                    state.get_history().unwrap(),
+                    state.text(),
+                    state.timezone(),
+                    state.units(),
+                    ctx.clone(),
+                );
+                let history_label = gtk::Label::new(Some(&state.text().history()));
+                notebook.prepend_page(&history.widget(), Some(&history_label));
+                (Some(history_label), Some(history))
+            }
+        };
 
         notebook.show();
         widget.add(&notebook);
@@ -49,16 +55,22 @@ impl MainWindow {
     pub fn update_from(&mut self, message: Message) {
         match message {
             Message::ChangeRange { range, records } => {
-                self.history.set_range(range);
-                self.history.set_records(records);
+                if let Some(ref mut history) = self.history {
+                    history.set_range(range);
+                    history.set_records(records);
+                };
             }
-            Message::ChangeSettings { settings } => {
-                self.history_label.set_markup(&settings.text.history());
-                self.settings_label.set_markup(&settings.text.preferences());
-                self.history.set_settings(settings);
+            Message::ChangeLanguage(text) => {
+                self.history_label
+                    .as_ref()
+                    .map(|label| label.set_markup(&text.history()));
+                self.settings_label.set_markup(&text.preferences());
+                // self.history.set_language(state);
             }
-            Message::RecordsUpdated { records } => {
-                self.history.set_records(records);
+            Message::ChangeTimezone(timezone) => (), // self.history.set_timezone(state),
+            Message::ChangeUnits(units) => (),       // self.history.set_units(state),
+            Message::RecordsUpdated(records) => {
+                self.history.as_mut().map(|h| h.set_records(records));
             }
         }
     }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -55,3 +55,15 @@ impl Component for gtk::Box {
         self.clone().upcast::<gtk::Widget>()
     }
 }
+
+impl Component for gtk::Button {
+    fn widget(&self) -> gtk::Widget {
+        self.clone().upcast::<gtk::Widget>()
+    }
+}
+
+impl Component for gtk::FileChooserButton {
+    fn widget(&self) -> gtk::Widget {
+        self.clone().upcast::<gtk::Widget>()
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -13,6 +13,7 @@ macro_rules! enclose {
             move |$(enclose!(@param $p),)+| $body
         }
     );
+    //(lifetime, $($n:ident),+ => move
 }
 
 use gtk::prelude::*;

--- a/src/components/rep_duration.rs
+++ b/src/components/rep_duration.rs
@@ -17,10 +17,7 @@ fn sets_c(sets: &Vec<Second<f64>>) -> gtk::Label {
     gtk::Label::new(Some(&set_strs.join(" ")))
 }
 
-pub fn rep_duration_c(
-    record: &fitnesstrax::repduration::RepDurationRecord,
-    _settings: &Settings,
-) -> gtk::Box {
+pub fn rep_duration_c(record: &fitnesstrax::repduration::RepDurationRecord) -> gtk::Box {
     let container = gtk::Box::new(gtk::Orientation::Horizontal, 5);
 
     container.add(&activity_c(&record.activity));

--- a/src/components/set_rep.rs
+++ b/src/components/set_rep.rs
@@ -1,6 +1,5 @@
 use gtk::prelude::*;
 
-use crate::settings::Settings;
 use fitnesstrax;
 
 fn activity_c(activity: &fitnesstrax::setrep::ActivityType) -> gtk::Label {
@@ -16,7 +15,7 @@ fn sets_c(sets: &Vec<u32>) -> gtk::Label {
     gtk::Label::new(Some(&set_strs.join(" ")))
 }
 
-pub fn set_rep_c(record: &fitnesstrax::setrep::SetRepRecord, _settings: &Settings) -> gtk::Box {
+pub fn set_rep_c(record: &fitnesstrax::setrep::SetRepRecord) -> gtk::Box {
     let container = gtk::Box::new(gtk::Orientation::Horizontal, 5);
 
     container.add(&activity_c(&record.activity));

--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -159,7 +159,7 @@ fn language_menu(text: &Text, component: Rc<RefCell<Settings>>) -> gtk::Widget {
         text.language().as_str(),
         dropmenu_c(
             MenuOptions(vec![("en", "English"), ("eo", "Esperanto")]),
-            text.language_id(),
+            text.language_id().get_language(),
             Box::new(move |s| component.borrow_mut().set_language(s)),
         ),
     )

--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -65,6 +65,9 @@ impl Settings {
             let ctx = ctx.clone();
             let chooser =
                 gtk::FileChooserButton::new("database file", gtk::FileChooserAction::Open);
+            if let Some(sp) = series_path {
+                chooser.set_filename(sp);
+            }
             chooser.connect_file_set(move |chooser| {
                 if let Some(filename) = chooser.get_filename() {
                     ctx.write().unwrap().set_series_path(filename);

--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -1,6 +1,7 @@
 use chrono_tz::Tz;
 use gtk::prelude::*;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
@@ -62,14 +63,16 @@ impl Settings {
 
         {
             let ctx = ctx.clone();
+            let chooser =
+                gtk::FileChooserButton::new("database file", gtk::FileChooserAction::Open);
+            chooser.connect_file_set(move |chooser| {
+                if let Some(filename) = chooser.get_filename() {
+                    ctx.write().unwrap().set_series_path(filename);
+                }
+            });
             component.database_path_widget.swap(Some(labeled_widget_c(
                 &settings.text.database_path(),
-                text_entry_c(
-                    &(series_path
-                        .and_then(|v| v.to_str().and_then(|v| Some(String::from(v))))
-                        .unwrap_or(String::from(""))),
-                    Box::new(move |s| ctx.write().unwrap().set_series_path(s)),
-                ),
+                chooser,
             )));
         }
 
@@ -122,7 +125,7 @@ impl Settings {
             &text.database_path(),
             text_entry_c(
                 &series_path.unwrap_or(String::from("")),
-                Box::new(move |s| ctx.write().unwrap().set_series_path(s)),
+                Box::new(move |s| ctx.write().unwrap().set_series_path(PathBuf::from(s))),
             ),
         )));
 

--- a/src/components/steps.rs
+++ b/src/components/steps.rs
@@ -4,16 +4,16 @@ use gtk::prelude::*;
 
 use crate::components::validated_text_entry_c;
 use crate::errors::Error;
-use crate::settings::Settings;
+use crate::i18n::Text;
 
-pub fn steps_c(record: &fitnesstrax::steps::StepRecord, settings: &Settings) -> gtk::Label {
-    gtk::Label::new(Some(&settings.text.step_count(record.steps)))
+pub fn steps_c(record: &fitnesstrax::steps::StepRecord, text: &Text) -> gtk::Label {
+    gtk::Label::new(Some(&text.step_count(record.steps)))
 }
 
 pub fn steps_edit_c(
     id: UniqueId,
     record: StepRecord,
-    settings: &Settings,
+    text: &Text,
     on_update: Box<dyn Fn(UniqueId, StepRecord)>,
 ) -> gtk::Box {
     let b = gtk::Box::new(gtk::Orientation::Horizontal, 5);
@@ -24,7 +24,7 @@ pub fn steps_edit_c(
         Box::new(|s| s.parse::<u32>().map_err(|_err| Error::ParseStepsError)),
         Box::new(move |val| on_update(id.clone(), StepRecord::new(record.timestamp(), val))),
     );
-    let label = gtk::Label::new(Some(&settings.text.steps_label()));
+    let label = gtk::Label::new(Some(&text.steps_label()));
 
     b.pack_start(&entry, false, false, 5);
     b.pack_start(&label, false, false, 5);

--- a/src/components/time_distance.rs
+++ b/src/components/time_distance.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::components::time_distance_row::time_distance_record_edit_c;
-use crate::settings::Settings;
+use crate::i18n::{Text, UnitSystem};
 
 #[derive(Clone)]
 pub struct TimeDistanceEdit {
@@ -14,7 +14,9 @@ pub struct TimeDistanceEdit {
     record_box: gtk::Box,
 
     records: HashMap<UniqueId, TimeDistanceRecord>,
-    settings: Settings,
+    timezone: chrono_tz::Tz,
+    text: Text,
+    units: UnitSystem,
     updated_records: Rc<RefCell<HashMap<UniqueId, TimeDistanceRecord>>>,
     new_records: Rc<RefCell<HashMap<UniqueId, TimeDistanceRecord>>>,
 }
@@ -23,7 +25,9 @@ impl TimeDistanceEdit {
     pub fn new(
         date: chrono::Date<chrono_tz::Tz>,
         records: Vec<(&UniqueId, &TimeDistanceRecord)>,
-        settings: Settings,
+        timezone: chrono_tz::Tz,
+        text: Text,
+        units: UnitSystem,
     ) -> TimeDistanceEdit {
         let mut record_hash: HashMap<UniqueId, TimeDistanceRecord> = HashMap::new();
         for (id, rec) in records.iter() {
@@ -41,15 +45,16 @@ impl TimeDistanceEdit {
             record_box,
 
             records: record_hash,
-            settings: settings.clone(),
+            timezone,
+            text: text.clone(),
+            units,
             updated_records,
             new_records: new_records.clone(),
         };
 
         let button_box = {
             let button_box = gtk::Box::new(gtk::Orientation::Horizontal, 5);
-            let new_button =
-                gtk::Button::new_with_label(&settings.text.add_time_distance_workout());
+            let new_button = gtk::Button::new_with_label(&text.add_time_distance_workout());
             new_button.show();
             button_box.pack_start(&new_button, false, false, 5);
             new_button.connect_clicked(enclose!(w, new_records => move |_| {
@@ -94,7 +99,9 @@ impl TimeDistanceEdit {
                         &time_distance_record_edit_c(
                             id.clone(),
                             rec.clone(),
-                            self.settings.clone(),
+                            self.timezone.clone(),
+                            &self.text,
+                            &self.units,
                             Box::new(move |id, rec| {
                                 updated_records.borrow_mut().insert(id, rec);
                             }),
@@ -109,7 +116,9 @@ impl TimeDistanceEdit {
                         &time_distance_record_edit_c(
                             id.clone(),
                             record.clone(),
-                            self.settings.clone(),
+                            self.timezone.clone(),
+                            &self.text,
+                            &self.units,
                             Box::new(move |id, rec| {
                                 updated_records.borrow_mut().insert(id, rec);
                             }),
@@ -128,7 +137,9 @@ impl TimeDistanceEdit {
                 &time_distance_record_edit_c(
                     id.clone(),
                     record.clone(),
-                    self.settings.clone(),
+                    self.timezone.clone(),
+                    &self.text,
+                    &self.units,
                     Box::new(move |id, rec| {
                         new_records.borrow_mut().insert(id, rec);
                     }),

--- a/src/components/weight.rs
+++ b/src/components/weight.rs
@@ -4,21 +4,22 @@ use gtk::prelude::*;
 
 use crate::components::basics::validated_text_entry_c;
 use crate::errors::Error;
-use crate::settings::Settings;
+use crate::i18n::{Text, UnitSystem};
 
-pub fn weight_record_c(record: &WeightRecord, settings: &Settings) -> gtk::Label {
-    gtk::Label::new(Some(&settings.text.mass(record.weight.clone())))
+pub fn weight_record_c(record: &WeightRecord, text: &Text) -> gtk::Label {
+    gtk::Label::new(Some(&text.mass(record.weight.clone())))
 }
 
 pub fn weight_record_edit_c(
     id: UniqueId,
     record: WeightRecord,
-    settings: &Settings,
+    text: &Text,
+    units: UnitSystem,
     on_update: Box<dyn Fn(UniqueId, WeightRecord)>,
 ) -> gtk::Box {
     let b = gtk::Box::new(gtk::Orientation::Horizontal, 5);
-    let u1 = settings.units.clone();
-    let u2 = settings.units.clone();
+    let u1 = units.clone();
+    let u2 = units.clone();
     let entry = validated_text_entry_c(
         record.weight,
         Box::new(move |w| u1.render_mass(w.clone())),
@@ -35,7 +36,7 @@ pub fn weight_record_edit_c(
         Box::new(move |val| on_update(id.clone(), WeightRecord::new(record.timestamp(), val))),
     );
 
-    let units_label = gtk::Label::new(Some(&settings.text.mass_label()));
+    let units_label = gtk::Label::new(Some(&text.mass_label()));
 
     b.pack_start(&entry, false, false, 5);
     b.pack_start(&units_label, false, false, 5);

--- a/src/components/weight.rs
+++ b/src/components/weight.rs
@@ -6,8 +6,8 @@ use crate::components::basics::validated_text_entry_c;
 use crate::errors::Error;
 use crate::i18n::{Text, UnitSystem};
 
-pub fn weight_record_c(record: &WeightRecord, text: &Text) -> gtk::Label {
-    gtk::Label::new(Some(&text.mass(record.weight.clone())))
+pub fn weight_record_c(record: &WeightRecord, text: &Text, units: &UnitSystem) -> gtk::Label {
+    gtk::Label::new(Some(&text.mass(record.weight.clone(), units)))
 }
 
 pub fn weight_record_edit_c(

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,12 @@ impl From<&LanguageId> for LanguageIdentifier {
     }
 }
 
+impl From<&LanguageIdentifier> for LanguageId {
+    fn from(lang: &LanguageIdentifier) -> LanguageId {
+        LanguageId(lang.clone())
+    }
+}
+
 impl Serialize for LanguageId {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(self.0.get_language())

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::config::Configuration;
 use crate::errors::{Error, Result};
+use crate::i18n::{Text, UnitSystem};
 use crate::range::Range;
 use crate::settings::Settings;
 use crate::types::DateRange;
@@ -16,34 +17,148 @@ pub enum Message {
         range: DateRange,
         records: Vec<(UniqueId, TraxRecord)>,
     },
-    ChangeSettings {
-        settings: Settings,
-    },
-    RecordsUpdated {
-        records: Vec<(UniqueId, TraxRecord)>,
-    },
+    ChangeLanguage(Text),
+    ChangeTimezone(chrono_tz::Tz),
+    ChangeUnits(UnitSystem),
+    RecordsUpdated(Vec<(UniqueId, TraxRecord)>),
 }
 
-pub struct AppContext {
+pub struct Application {
+    channel: Sender<Message>,
+    state: State,
+}
+
+pub enum State {
+    Unconfigured(Unconfigured),
+    Configured(Configured),
+}
+
+pub struct Unconfigured {
     settings: Settings,
     series_path: Option<PathBuf>,
-    trax: Option<Trax>,
-    range: DateRange,
-    channel: Sender<Message>,
 }
 
-impl AppContext {
-    pub fn new(channel: Sender<Message>) -> Result<AppContext> {
-        let config = Configuration::load_from_yaml();
+pub struct Configured {
+    settings: Settings,
+    series_path: PathBuf,
+    trax: Trax,
+    range: DateRange,
+}
 
-        let trax = if let Some(ref path) = config.series_path {
-            fitnesstrax::Trax::new(fitnesstrax::Params {
-                series_path: path.clone(),
+impl State {
+    pub fn series_path(&self) -> Option<&PathBuf> {
+        match self {
+            State::Unconfigured(Unconfigured { series_path, .. }) => series_path.as_ref(),
+            State::Configured(Configured { series_path, .. }) => Some(&series_path),
+        }
+    }
+
+    pub fn settings(&self) -> &Settings {
+        match self {
+            State::Unconfigured(Unconfigured { settings, .. }) => &settings,
+            State::Configured(Configured { settings, .. }) => &settings,
+        }
+    }
+
+    pub fn text(&self) -> &Text {
+        match self {
+            State::Unconfigured(Unconfigured { settings, .. }) => &settings.text,
+            State::Configured(Configured { settings, .. }) => &settings.text,
+        }
+    }
+
+    fn set_language(&mut self, language_str: &str) {
+        match self {
+            State::Unconfigured(Unconfigured { settings, .. }) => {
+                settings.set_language(language_str)
+            }
+            State::Configured(Configured { settings, .. }) => settings.set_language(language_str),
+        }
+    }
+
+    fn set_timezone(&mut self, timezone: chrono_tz::Tz) {
+        match self {
+            State::Unconfigured(Unconfigured {
+                ref mut settings, ..
+            }) => settings.set_timezone(timezone),
+            State::Configured(Configured {
+                ref mut settings, ..
+            }) => settings.set_timezone(timezone),
+        }
+    }
+
+    fn set_units(&mut self, units_str: &str) {
+        match self {
+            State::Unconfigured(Unconfigured {
+                ref mut settings, ..
+            }) => settings.set_units(units_str),
+            State::Configured(Configured {
+                ref mut settings, ..
+            }) => settings.set_units(units_str),
+        }
+    }
+}
+
+impl Configured {
+    pub fn range(&self) -> DateRange {
+        self.range.clone()
+    }
+
+    pub fn get_history(&self) -> Result<Vec<(UniqueId, TraxRecord)>> {
+        let start_time = DateTimeTz(
+            self.range
+                .start
+                .and_hms(0, 0, 0)
+                .with_timezone(&self.settings.timezone),
+        );
+        let end_time = DateTimeTz(
+            (self.range.end + chrono::Duration::days(1))
+                .and_hms(0, 0, 0)
+                .with_timezone(&self.settings.timezone),
+        );
+        self.trax
+            .get_history(start_time, end_time)
+            .map(|v| {
+                v.iter()
+                    .map(|(ref id, ref record)| ((*id).clone(), (*record).clone()))
+                    .collect()
             })
-            .map(Some)
-        } else {
-            Ok(None)
-        }?;
+            .map_err(|err| Error::TraxError(err))
+    }
+
+    pub fn save_records(
+        &mut self,
+        updated_records: Vec<(UniqueId, TraxRecord)>,
+        new_records: Vec<TraxRecord>,
+    ) {
+        for (id, record) in updated_records {
+            let _ = self.trax.replace_record(id, record);
+        }
+        for record in new_records {
+            let _ = self.trax.add_record(record);
+        }
+    }
+
+    pub fn set_range(&mut self, range: DateRange) {
+        self.range = range;
+    }
+
+    pub fn text(&self) -> &Text {
+        &self.settings.text
+    }
+
+    pub fn timezone(&self) -> &chrono_tz::Tz {
+        &self.settings.timezone
+    }
+
+    pub fn units(&self) -> &UnitSystem {
+        &self.settings.units
+    }
+}
+
+impl Application {
+    pub fn new(channel: Sender<Message>) -> Result<Application> {
+        let config = Configuration::load_from_yaml();
 
         let range = Range::new(
             Utc::now().with_timezone(&config.timezone).date() - chrono::Duration::days(7),
@@ -52,99 +167,86 @@ impl AppContext {
 
         let settings = Settings::from_config(&config);
 
-        Ok(AppContext {
-            series_path: config.series_path,
-            settings,
-            trax,
-            range,
-            channel,
-        })
+        let state = if let Some(ref path) = config.series_path {
+            State::Configured(Configured {
+                trax: fitnesstrax::Trax::new(fitnesstrax::Params {
+                    series_path: path.clone(),
+                })
+                .unwrap(),
+                series_path: path.clone(),
+                range,
+                settings,
+            })
+        } else {
+            State::Unconfigured(Unconfigured {
+                series_path: None,
+                settings,
+            })
+        };
+
+        Ok(Application { channel, state })
     }
 
-    pub fn get_series_path(&self) -> Option<&PathBuf> {
-        self.series_path.as_ref()
+    pub fn get_state(&self) -> &State {
+        &self.state
     }
 
     pub fn set_series_path(&mut self, path: &str) {
-        self.series_path = Some(PathBuf::from(path));
-    }
+        let trax = fitnesstrax::Trax::new(fitnesstrax::Params {
+            series_path: PathBuf::from(path),
+        })
+        .unwrap();
 
-    pub fn get_settings(&self) -> Settings {
-        self.settings.clone()
+        let range = Range::new(
+            Utc::now()
+                .with_timezone(&self.state.settings().timezone)
+                .date()
+                - chrono::Duration::days(7),
+            Utc::now()
+                .with_timezone(&self.state.settings().timezone)
+                .date(),
+        );
+
+        self.state = match self.state {
+            State::Unconfigured(Unconfigured { ref settings, .. }) => {
+                State::Configured(Configured {
+                    trax,
+                    series_path: PathBuf::from(path),
+                    range,
+                    settings: settings.clone(),
+                })
+            }
+            State::Configured(Configured {
+                ref range,
+                ref settings,
+                ..
+            }) => State::Configured(Configured {
+                trax,
+                series_path: PathBuf::from(path),
+                range: range.clone(),
+                settings: settings.clone(),
+            }),
+        }
     }
 
     pub fn set_language(&mut self, language_str: &str) {
-        self.settings.set_language(language_str);
-        self.send_notifications(Message::ChangeSettings {
-            settings: self.settings.clone(),
-        });
+        self.state.set_language(language_str);
+        if let State::Configured(ref state) = self.state {
+            self.send_notifications(Message::ChangeLanguage(state.settings.text.clone()));
+        }
     }
 
     pub fn set_timezone(&mut self, timezone: chrono_tz::Tz) {
-        self.settings.set_timezone(timezone);
-        self.send_notifications(Message::ChangeSettings {
-            settings: self.settings.clone(),
-        });
+        self.state.set_timezone(timezone);
+        if let State::Configured(ref state) = self.state {
+            self.send_notifications(Message::ChangeTimezone(state.settings.timezone.clone()));
+        }
     }
 
     pub fn set_units(&mut self, units_str: &str) {
-        self.settings.set_units(units_str);
-        self.send_notifications(Message::ChangeSettings {
-            settings: self.settings.clone(),
-        });
-    }
-
-    /*
-    pub fn set_settings(&mut self, settings: Settings) {
-        {
-            if settings.text != self.settings.language {
-                self.translations = Translations::new(&settings.language);
-            }
-            self.settings = settings;
-
-            let config = Configuration {
-                series_path: self.series_path.clone(),
-                language: self.settings.language.clone(),
-                timezone: self.settings.timezone,
-                units: String::from(self.settings.units.clone()),
-            };
-            config.save_to_yaml();
-        }
-        self.send_notifications(Message::ChangePreferences {
-            settings: self.settings.clone(),
-            range: self.range.clone(),
-            records: self.get_history().unwrap(),
-        });
-    }
-    */
-
-    pub fn get_range(&self) -> DateRange {
-        self.range.clone()
-    }
-
-    pub fn get_history(&self) -> Result<Vec<(UniqueId, TraxRecord)>> {
-        match self.trax {
-            None => Err(Error::SeriesNotOpen),
-            Some(ref trax) => {
-                let start_time = DateTimeTz(
-                    self.range
-                        .start
-                        .and_hms(0, 0, 0)
-                        .with_timezone(&self.settings.timezone),
-                );
-                let end_time = DateTimeTz(
-                    (self.range.end + chrono::Duration::days(1))
-                        .and_hms(0, 0, 0)
-                        .with_timezone(&self.settings.timezone),
-                );
-                trax.get_history(start_time, end_time)
-                    .map(|v| {
-                        v.iter()
-                            .map(|(ref id, ref record)| ((*id).clone(), (*record).clone()))
-                            .collect()
-                    })
-                    .map_err(|err| Error::TraxError(err))
-            }
+        self.state.set_units(units_str);
+        if let State::Configured(ref state) = self.state {
+            self.send_notifications(Message::ChangeUnits(state.settings.units.clone()));
         }
     }
 
@@ -153,29 +255,42 @@ impl AppContext {
         updated_records: Vec<(UniqueId, TraxRecord)>,
         new_records: Vec<TraxRecord>,
     ) -> Result<()> {
-        match self.trax {
-            None => Err(Error::SeriesNotOpen),
-            Some(ref mut trax) => {
-                for (id, record) in updated_records {
-                    let _ = trax.replace_record(id, record);
-                }
-                for record in new_records {
-                    let _ = trax.add_record(record);
-                }
-                let history = self.get_history().unwrap();
-                self.send_notifications(Message::RecordsUpdated { records: history });
+        match self.state {
+            State::Unconfigured(_) => Err(Error::SeriesNotOpen),
+            State::Configured(ref mut state) => {
+                state.save_records(updated_records, new_records);
+                Ok(())
+            }
+        }?;
+        match self.state {
+            State::Unconfigured(_) => Err(Error::SeriesNotOpen),
+            State::Configured(ref state) => {
+                self.send_notifications(Message::RecordsUpdated(
+                    state.get_history().unwrap().clone(),
+                ));
                 Ok(())
             }
         }
     }
 
-    pub fn set_range(&mut self, range: DateRange) {
-        self.range = range.clone();
-        let history = self.get_history().unwrap();
-        self.send_notifications(Message::ChangeRange {
-            range,
-            records: history,
-        });
+    pub fn set_range(&mut self, range: DateRange) -> Result<()> {
+        match self.state {
+            State::Unconfigured(_) => Err(Error::SeriesNotOpen),
+            State::Configured(ref mut state) => {
+                state.set_range(range);
+                Ok(())
+            }
+        }?;
+        match self.state {
+            State::Unconfigured(_) => Err(Error::SeriesNotOpen),
+            State::Configured(ref state) => {
+                self.send_notifications(Message::ChangeRange {
+                    range: state.range().clone(),
+                    records: state.get_history().unwrap().clone(),
+                });
+                Ok(())
+            }
+        }
     }
 
     fn send_notifications(&self, msg: Message) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,6 +45,9 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
+    /* description() is deprecated:
+     * https://rust-lang.github.io/api-guidelines/interoperability.html#error-types-are-meaningful-and-well-behaved-c-good-err
+     * */
     fn description(&self) -> &str {
         match self {
             Error::ParseDistanceError => "Failed to parse a distance string",

--- a/src/i18n/text.rs
+++ b/src/i18n/text.rs
@@ -259,10 +259,10 @@ mod test {
 
     #[test]
     fn translations_work() {
-        let en = Text::new("en-US".parse().unwrap(), UnitSystem::SI);
+        let en = Text::new("en-US".parse().unwrap());
         assert_eq!(en.preferences(), "Preferences");
 
-        let eo = Text::new("eo".parse().unwrap(), UnitSystem::SI);
+        let eo = Text::new("eo".parse().unwrap());
         assert_eq!(eo.preferences(), "Agdoroj");
         assert_eq!(eo.history(), "Historio");
     }

--- a/src/i18n/text.rs
+++ b/src/i18n/text.rs
@@ -124,13 +124,12 @@ impl Text {
 
         Text {
             language: langid.clone(),
-            units,
             bundle: Arc::new(bundle),
         }
     }
 
-    pub fn language_id(&self) -> &str {
-        self.language.get_language()
+    pub fn language_id(&self) -> &LanguageIdentifier {
+        &self.language
     }
 
     pub fn activity<'s>(&'s self) -> String {

--- a/src/i18n/text.rs
+++ b/src/i18n/text.rs
@@ -87,7 +87,6 @@ weight = Pezo
 #[derive(Clone)]
 pub struct Text {
     language: LanguageIdentifier,
-    units: UnitSystem,
     bundle: Arc<FluentBundle<FluentResource>>,
 }
 
@@ -116,7 +115,7 @@ fn add_language(bundle: &mut FluentBundle<FluentResource>, langid: &LanguageIden
 }
 
 impl Text {
-    pub fn new(langid: LanguageIdentifier, units: UnitSystem) -> Text {
+    pub fn new(langid: LanguageIdentifier) -> Text {
         let english_id: LanguageIdentifier = "en".parse().unwrap();
         let mut bundle = FluentBundle::new(&[langid.clone(), english_id.clone()]);
 
@@ -166,10 +165,10 @@ impl Text {
         self.tr("language", None).unwrap()
     }
 
-    pub fn mass(&self, value: Kilogram<f64>) -> String {
+    pub fn mass(&self, value: Kilogram<f64>, units: &UnitSystem) -> String {
         let mut args = FluentArgs::new();
-        args.insert("value", FluentValue::from(self.units.render_mass(value)));
-        args.insert("units", FluentValue::from(String::from(&self.units)));
+        args.insert("value", FluentValue::from(units.render_mass(value)));
+        args.insert("units", FluentValue::from(String::from(units)));
 
         self.tr("mass", Some(&args)).unwrap()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     application.connect_activate(move |app| {
         let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        let ctx = Arc::new(RwLock::new(context::AppContext::new(tx).unwrap()));
+        let ctx = Arc::new(RwLock::new(context::Application::new(tx).unwrap()));
         let gui = Arc::new(RwLock::new(components::MainWindow::new(ctx.clone(), app)));
 
         let gui_clone = gui.clone();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,7 @@ pub struct Settings {
 
 impl Settings {
     pub fn new(langid: LanguageIdentifier, units: UnitSystem, timezone: chrono_tz::Tz) -> Settings {
-        let text = Text::new(langid, units.clone());
+        let text = Text::new(langid);
 
         Settings {
             timezone,
@@ -33,7 +33,7 @@ impl Settings {
 
     pub fn set_language(&mut self, lang_str: &str) {
         let langid = lang_str.parse().expect("Language parsing failed");
-        self.text = Text::new(langid, self.units.clone());
+        self.text = Text::new(langid);
     }
 
     pub fn set_units(&mut self, units_str: &str) {


### PR DESCRIPTION
# Description

This provides an initial state for configuration, where only the configuration options are shown until a database file has been chosen. After that, the history window gets created and populated.

I split the state into "Unconfigured" and "Configured" states, and then require that History cannot be instantiated without a Configured state. And yet, even that fell apart over time as I stopped passing anything other than the individual relevant components to the underlying system.

I am going to study some other applications before I change the state model again, because I feel that other people have probably invented better things.

# Stories

* Present the configuration interface when there is no configuration file available #70
* Support database path selection #82
