### PR TITLE
Use GSettings for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ client/index.js
 db.series
 result
 config.yaml
+gschemas.compiled

--- a/share/com.luminescent-dreams.fitnesstrax.gschema.xml
+++ b/share/com.luminescent-dreams.fitnesstrax.gschema.xml
@@ -1,0 +1,40 @@
+<schemalist>
+    <schema id="com.luminescent-dreams.fitnesstrax" path="/com/luminescent-dreams/fitnesstrax/">
+        <key name="series-path" type="s">
+            <default>""</default>
+            <summary>Path to the health and fitness series</summary>
+            <description> Path to the health and fitness series </description>
+        </key>
+
+        <key name="language" type="s">
+            <summary>Language</summary>
+            <description>Language for the application</description>
+            <default>"en"</default>
+            <choices>
+                <choice value="en" />
+                <choice value="eo" />
+            </choices>
+        </key>
+
+        <key name="timezone" type="s">
+            <summary>Timezone</summary>
+            <description>What time zone are you in right now?</description>
+            <default>"Etc/UTC"</default>
+            <choices>
+                <choice value="America/Chicago" />
+                <choice value="America/New_York" />
+                <choice value="Etc/UTC" />
+            </choices>
+        </key>
+
+        <key name="units" type="s">
+            <summary>Units System</summary>
+            <description>Units System</description>
+            <default>"SI"</default>
+            <choices>
+                <choice value="SI" />
+                <choice value="USA" />
+            </choices>
+        </key>
+    </schema>
+</schemalist>

--- a/src/components/settings.rs
+++ b/src/components/settings.rs
@@ -176,6 +176,7 @@ fn timezone_menu(text: &Text, timezone: &Tz, component: Rc<RefCell<Settings>>) -
         &text.timezone(),
         dropmenu_c(
             MenuOptions(vec![
+                ("Etc/UTC", "UTC"),
                 ("America/Chicago", "United States: Chicago"),
                 ("America/New_York", "United States: New York"),
             ]),

--- a/src/context.rs
+++ b/src/context.rs
@@ -176,7 +176,7 @@ impl Configured {
 
 impl Application {
     pub fn new(channel: Sender<Message>) -> Result<Application> {
-        let config = Configuration::load_from_yaml();
+        let config = Configuration::load_from_gsettings();
 
         let range = Range::new(
             Utc::now().with_timezone(&config.timezone).date() - chrono::Duration::days(7),
@@ -216,7 +216,7 @@ impl Application {
             timezone: self.state.settings().timezone.clone(),
             units: self.state.settings().units.clone(),
         };
-        config.save_to_yaml();
+        config.save_to_gsettings();
     }
 
     pub fn set_series_path(&mut self, path: PathBuf) {


### PR DESCRIPTION
# Description

Instead of using a configuration file, use the GSettings interface so that there are no stray files laying around and the settings are more carefully managed.

# Stories

* Switch from file based configuration to GSettings #108
