### PR TITLE
Add an about page with all licensing information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-dependencies = [
- "memchr 2.2.1",
-]
-
-[[package]]
 name = "atk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,7 +236,6 @@ dependencies = [
  "gio",
  "glib",
  "gtk",
- "regex 1.3.1",
  "serde",
  "serde_yaml",
  "tzdata",
@@ -841,18 +831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
-dependencies = [
- "aho-corasick 0.7.6",
- "memchr 2.2.1",
- "regex-syntax 0.6.12",
- "thread_local 0.3.6",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,12 +844,6 @@ checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 dependencies = [
  "ucd-util",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ fluent = "0.9.1"
 gio = { version = "", features = ["v2_44"] }
 glib = "0.9.0"
 gtk = { version = "0.8.0", features = ["v3_16"] }
-regex = "1.3.1"
 serde = { version = "1.0.102", features = ["derive"] }
 serde_yaml = "*"
 tzdata = "0.4.1"

--- a/src/components/about.rs
+++ b/src/components/about.rs
@@ -1,0 +1,56 @@
+use gtk::prelude::*;
+
+use crate::components::Component;
+use crate::i18n::Text;
+
+#[derive(Clone)]
+pub struct About {
+    widget: gtk::Box,
+}
+
+impl About {
+    pub fn new(text: &Text) -> About {
+        let widget = gtk::Box::new(gtk::Orientation::Vertical, 5);
+
+        widget.pack_start(
+            &gtk::Label::new(Some(&text.name_with_version())),
+            false,
+            false,
+            0,
+        );
+
+        let no_adjustment: Option<&gtk::Adjustment> = None;
+        let scrolling_info = gtk::ScrolledWindow::new(no_adjustment, no_adjustment);
+
+        let tag_table: Option<&gtk::TextTagTable> = None;
+
+        let dependencies_buffer = gtk::TextBuffer::new(tag_table);
+        dependencies_buffer.set_text(&text.dependencies());
+        let dependencies_view = gtk::TextView::new_with_buffer(&dependencies_buffer);
+
+        let license_buffer = gtk::TextBuffer::new(tag_table);
+        license_buffer.set_text(&text.license());
+        let license_view = gtk::TextView::new_with_buffer(&license_buffer);
+
+        let info_box = gtk::Box::new(gtk::Orientation::Vertical, 5);
+        info_box.pack_start(&dependencies_view, false, false, 0);
+        info_box.pack_start(&license_view, false, false, 0);
+
+        scrolling_info.add(&info_box);
+        scrolling_info.show();
+
+        widget.pack_start(&scrolling_info, true, true, 0);
+
+        widget.show_all();
+
+        About { widget }
+    }
+
+    pub fn set_language(&mut self, text: &Text) {}
+}
+
+impl Component for About {
+    fn widget(&self) -> gtk::Widget {
+        self.widget.clone().upcast::<gtk::Widget>()
+    }
+}

--- a/src/components/main_window.rs
+++ b/src/components/main_window.rs
@@ -8,7 +8,7 @@ pub struct MainWindow {
     notebook: gtk::Notebook,
     history_idx: Option<u32>,
     history_page: Option<Page<History>>,
-    //settings_idx: u32,
+    about_page: Page<About>,
     settings_page: Page<Settings>,
     ctx: Arc<RwLock<Application>>,
 }
@@ -24,6 +24,13 @@ impl MainWindow {
         let notebook = gtk::Notebook::new();
 
         let settings_page = Page::new(&state.text().preferences(), Settings::new(ctx.clone()));
+        notebook.append_page(
+            &settings_page.component.widget(),
+            Some(&settings_page.label),
+        );
+
+        let about_page = Page::new(&state.text().about(), About::new(state.text()));
+        notebook.append_page(&about_page.component.widget(), Some(&about_page.label));
 
         let history_page = match state {
             State::Unconfigured(_) => None,
@@ -39,16 +46,6 @@ impl MainWindow {
                 Some(Page::new(&state.text().history(), history))
             }
         };
-
-        notebook.show();
-        widget.add(&notebook);
-        widget.show();
-
-        /*let settings_idx =*/
-        notebook.append_page(
-            &settings_page.component.widget(),
-            Some(&settings_page.label),
-        );
         let history_idx = match history_page {
             Some(ref page) => {
                 Some(notebook.prepend_page(&page.component.widget(), Some(&page.label)))
@@ -56,11 +53,15 @@ impl MainWindow {
             None => None,
         };
 
+        notebook.show();
+        widget.add(&notebook);
+        widget.show();
+
         let self_ = MainWindow {
             notebook,
             history_idx,
             history_page: history_page,
-            //settings_idx,
+            about_page,
             settings_page,
             ctx: ctx.clone(),
         };
@@ -110,6 +111,8 @@ impl MainWindow {
                     page.set_label(&text.history());
                     page.component.set_language(text.clone());
                 }
+                self.about_page.set_label(&text.about());
+                self.about_page.component.set_language(text);
                 self.settings_page.set_label(&text.preferences());
             }
             Message::ChangeTimezone(timezone) => {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,6 +18,7 @@ macro_rules! enclose {
 
 use gtk::prelude::*;
 
+mod about;
 mod basics;
 mod date_selector;
 mod day;
@@ -32,6 +33,7 @@ mod time_distance;
 mod time_distance_row;
 mod weight;
 
+pub use about::About;
 pub use basics::*;
 pub use date_selector::date_selector_c;
 pub use day::Day;

--- a/src/i18n/text.rs
+++ b/src/i18n/text.rs
@@ -8,11 +8,25 @@ use crate::i18n::UnitSystem;
 use fitnesstrax::timedistance;
 
 const ENGLISH_STRINGS: &str = "
+about = About
 activity = Activity
 add-time-distance-workout = Add Time/Distance Workout
 cancel = Cancel
 cycling = Cycling
 database-path = Database Path
+dependencies = Dependencies
+  chrono-tz 0.4, MIT/Apache-2.0, Djzin
+  chrono 0.4, MIT/Apache-2.0, Brandon W. Maister, Kang Seonghoon
+  dimensioned 0.7.0, MIT/Apache-2.0, Paho Lurie-Gregg
+  emseries 0.5.0, BSD-3-Clause, Savanni D'Gerine
+  fluent 0.9.1, Apache-2.0/MIT, Staś Małolepszy, Zibi Braniecki
+  gio, MIT, The Gtk-rs Project Developers
+  glib 0.9.0, MIT, The Gtk-rs Project Developers
+  gtk 0.8.0, MIT, The Gtk-rs Project Developers
+  serde 1, MIT/Apache-2.0, David Tolnay, Erick Tryzelaar
+  serde_yaml, MIT/Apache-2.0, David Tolnay
+  tzdata 0.4.1, MIT, Maxime Lenoir
+  unic-langid 0.7.1, MIT/Apache-2.0, Zibi Braniecki
 edit = Edit
 enter-distance = Enter distance
 enter-duration = Enter duration
@@ -20,6 +34,35 @@ enter-time = Enter time
 health-tracker = Health Tracker
 history = History
 language = Language
+license = Copyright Savanni D'Gerinel (c) 2018-2020
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  - Neither the name of Savanni D'Gerinel nor the names of other
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 mass = {$units ->
     *[SI] {$value} kilograms
     [USA] {$value} pounds
@@ -28,6 +71,7 @@ mass-label = {$units ->
     *[SI] kilograms
     [USA] pounds
 }
+name-with-version = FitnessTrax, version 0.1
 preferences = Preferences
 pushups = Pushups
 rowing = Rowing
@@ -132,7 +176,11 @@ impl Text {
         &self.language
     }
 
-    pub fn activity<'s>(&'s self) -> String {
+    pub fn about<'s>(&self) -> String {
+        self.tr("about", None).unwrap()
+    }
+
+    pub fn activity<'s>(&self) -> String {
         self.tr("activity", None).unwrap()
     }
 
@@ -148,8 +196,12 @@ impl Text {
         self.tr("cycling", None).unwrap()
     }
 
-    pub fn database_path<'s>(&'s self) -> String {
+    pub fn database_path(&self) -> String {
         self.tr("database-path", None).unwrap()
+    }
+
+    pub fn dependencies(&self) -> String {
+        self.tr("dependencies", None).unwrap()
     }
 
     pub fn edit(&self) -> String {
@@ -164,6 +216,10 @@ impl Text {
         self.tr("language", None).unwrap()
     }
 
+    pub fn license(&self) -> String {
+        self.tr("license", None).unwrap()
+    }
+
     pub fn mass(&self, value: Kilogram<f64>, units: &UnitSystem) -> String {
         let mut args = FluentArgs::new();
         args.insert("value", FluentValue::from(units.render_mass(value)));
@@ -174,6 +230,10 @@ impl Text {
 
     pub fn mass_label(&self) -> String {
         self.tr("mass-label", None).unwrap()
+    }
+
+    pub fn name_with_version(&self) -> String {
+        self.tr("name-with-version", None).unwrap()
     }
 
     pub fn preferences(&self) -> String {


### PR DESCRIPTION
# Description

A quick and dirty about page that includes a list of my dependencies and the text of the license. It looks terrible, but it gives credit and I can format it when I style the rest of the application.

# Stories

* About page #111